### PR TITLE
Update icons.less

### DIFF
--- a/src/components/icons.less
+++ b/src/components/icons.less
@@ -1,4 +1,25 @@
-@import 'https://fonts.googleapis.com/icon?family=Material+Icons';
+@font-face {
+font-family: 'Material Icons';
+font-style: normal;
+font-weight: 400;
+src: url(https://fonts.gstatic.com/s/materialicons/v34/2fcrYFNaTjcS6g4U3t-Y5ZjZjT5FdEJ140U2DJYC3mY.woff2) format('woff2');
+}
+
+.material-icons {
+font-family: 'Material Icons';
+font-weight: normal;
+font-style: normal;
+font-size: 24px;
+line-height: 1;
+letter-spacing: normal;
+text-transform: none;
+display: inline-block;
+white-space: nowrap;
+word-wrap: normal;
+direction: ltr;
+-webkit-font-feature-settings: 'liga';
+-webkit-font-smoothing: antialiased;
+}
 
 .material-icons {
   vertical-align: -23%;


### PR DESCRIPTION
Changing the line "@import 'https://fonts.googleapis.com/icon?family=Material+Icons';" to prevent the error:

🚨  [GIT_PATH]/facebook-comment-scraper/src/components/Root.less: Cannot find module './https://fonts.googleapis.com/icon?family=Material+Icons' from '[GIT_PATH]/fbscrapper/facebook-comment-scraper/src/components'